### PR TITLE
Fix for yarn and nvm global folder pickup

### DIFF
--- a/src/guides/installing.md
+++ b/src/guides/installing.md
@@ -53,6 +53,12 @@ To install Ember CLI Canary, run the following command to install it from the `m
 ```bash
 yarn global add ember-cli/ember-cli
 ```
+Note, if you are using a node version manager like NVM. Yarn may not find and install the package into the global folder for
+your currently selected node version. If this happens run this command.
+
+```bash
+yarn global add ember-cli/ember-cli --global-folder=‘yarn global bin’
+```
 
 Alternatively, you can do:
 


### PR DESCRIPTION
There is a issue when using a node version manager like nvm or nodenv when installing a global package with yarn. Yarn (v0.21) is not able to find the global folder for the currently selected node version. This is the current work around until it is patched.